### PR TITLE
Fallback to older version due to startup issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v1.8.2
     volumes:
       - ./prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus


### PR DESCRIPTION
When using the latest prometheus docker image, the container is exiting with code 1 and error message:
`prometheus_1  | Error parsing commandline arguments: unknown short flag '-c'`